### PR TITLE
Moved the elastic facade initialization before postFacadeInit call

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
@@ -234,11 +234,14 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
         screenFacade = new ScreenFacadeImpl(this)
         logger.info("Screen Facade initialized")
 
-        postFacadeInit()
-
-        // NOTE: ElasticFacade init after postFacadeInit() so finds embedded from moqui-elasticsearch if present, can move up once moqui-elasticsearch deprecated
+        /**
+         * NOTE: Moved ElasticFacade init before postFacadeInit() as the moqui-elasticsearch component is not being used.
+         * Before this change, the ElasticFacade was initialized after the postFacadeInit() method.
+         */
         elasticFacade = new ElasticFacadeImpl(this)
         logger.info("Elastic Facade initialized")
+
+        postFacadeInit()
 
         logger.info("Execution Context Factory initialized in ${(System.currentTimeMillis() - initStartTime)/1000} seconds")
     }


### PR DESCRIPTION
#### Issue:
When the framework creates the entities for elastic search, the NPE occurs due to an uninitialized `elasticFacade`.

#### Solution:
Previously, the `elasticFacade` was initialized after the postFacadeInit process expected that it would be initialized by `moqui-elasticsearch`. As we will not be using this component, The elastic facade initialization process will call before postFacadeInit.