### PR TITLE
Update: pageSize now defaults to moqui configuration instead of User Preference

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
@@ -355,19 +355,9 @@ class ScreenRenderImpl implements ScreenRender {
             // add URL parameters, if there were any in the URL (in path info or after ?)
             screenUrlInstance.addParameters(web.requestParameters)
 
-            // check for pageSize parameter, if set save in current user's preference, if not look up from user pref
-            if (ec.userFacade.userId != null) {
-                String pageSize = web.requestParameters.get("pageSize")
-                String userPageSize = ec.userFacade.getPreference("screen.user.page.size")
-                if (pageSize != null && pageSize.isInteger()) {
-                    if (!pageSize.equals(userPageSize))
-                        ec.userFacade.setPreference("screen.user.page.size", pageSize)
-                } else {
-                    if (userPageSize != null && userPageSize.isInteger()) {
-                        // don't add to parameters, just set internally: web.requestParameters.put("pageSize", userPageSize)
-                        ec.contextStack.put("pageSize", userPageSize)
-                    }
-                }
+            String pageSize = web.requestParameters.get("pageSize")
+            if(!pageSize) {
+                ec.contextStack.put("pageSize", System.getProperty("webapp_screen_page_size"))
             }
         }
 

--- a/framework/src/main/resources/MoquiDefaultConf.xml
+++ b/framework/src/main/resources/MoquiDefaultConf.xml
@@ -40,6 +40,7 @@
         AWS Cloudfront: CloudFront-Viewer-Address (requires config in Cloudfront origin request policy)
     -->
     <default-property name="webapp_client_ip_header" value=""/>
+    <default-property name="webapp_screen_page_size" value="20"/>
 
     <!-- Properties for the primary (transactional group) datasource -->
     <default-property name="entity_ds_db_conf" value="h2"/>


### PR DESCRIPTION
#### **Problem**

Passing `pageSize` in an API request or changing the view size on app screens was being saved as a user preference (`screen.user.page.size`). This caused unintended side effects — other screens or endpoints would fallback to this saved value even when `pageSize` wasn’t explicitly provided. This leads to confusing behavior, as users may not realize they’ve altered their default.

#### **What’s Changed**

* Removed logic that saves and loads `pageSize` from user preferences.
* Introduced a new default property in config: `webapp_screen_page_size`, used as the fallback when no `pageSize` is provided.