### PR TITLE
Improvment: Removed the 30 sec minimum idle timeout limit of RestClient

### DIFF
--- a/framework/src/main/java/org/moqui/util/RestClient.java
+++ b/framework/src/main/java/org/moqui/util/RestClient.java
@@ -311,7 +311,7 @@ public class RestClient {
         try {
             Request request = makeRequest(tempFactory != null ? tempFactory : (overrideRequestFactory != null ? overrideRequestFactory : getDefaultRequestFactory()));
             if (timeoutSeconds < 2) timeoutSeconds = 2;
-            request.idleTimeout(timeoutSeconds > 30 ? 30 : timeoutSeconds-1, TimeUnit.SECONDS);
+            request.idleTimeout(timeoutSeconds-1, TimeUnit.SECONDS);
             // use a FutureResponseListener so we can set the timeout and max response size (old: response = request.send(); )
             FutureResponseListener listener = new FutureResponseListener(request, maxResponseSize);
             try {


### PR DESCRIPTION
Removed the Idle Timeout on the RestClient, instead using the configured `timeoutSeconds - 1`.

This update allows waiting for a longer time in situations where Rest APIs take a longer duration to respond.

### Previous commit where the timeout was initially implemented
[In RestClient if a timeout is set, set timeout-1 as the idle timeout on the connection, otherwise the Jetty client seems to wait 30s anyway (30s is the default idle timeout)](https://github.com/moqui/moqui-framework/pull/559/commits/b1ca89754321ac62d3474b9c815b23bab0603a0f)