### PR TITLE
Pass job run id to service context when called from a service job

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/service/ServiceCallJobImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/service/ServiceCallJobImpl.groovy
@@ -237,6 +237,7 @@ class ServiceCallJobImpl extends ServiceCallImpl implements ServiceCallJob {
                         .disableAuthz().call()
 
                 if (lastRunTime != (Object) null) parameters.put("lastRunTime", lastRunTime)
+                if (jobRunId) parameters.put("_jobRunId", jobRunId)
 
                 // NOTE: authz is disabled because authz is checked before queueing
                 Map<String, Object> results = new HashMap<>()

--- a/patches/JobRunId.patch
+++ b/patches/JobRunId.patch
@@ -1,0 +1,14 @@
+diff --git framework/src/main/groovy/org/moqui/impl/service/ServiceCallJobImpl.groovy framework/src/main/groovy/org/moqui/impl/service/ServiceCallJobImpl.groovy
+old mode 100644
+new mode 100755
+index 8fa7c654..dde8d659
+--- framework/src/main/groovy/org/moqui/impl/service/ServiceCallJobImpl.groovy
++++ framework/src/main/groovy/org/moqui/impl/service/ServiceCallJobImpl.groovy
+@@ -237,6 +237,7 @@ class ServiceCallJobImpl extends ServiceCallImpl implements ServiceCallJob {
+                         .disableAuthz().call()
+ 
+                 if (lastRunTime != (Object) null) parameters.put("lastRunTime", lastRunTime)
++                if (jobRunId) parameters.put("_jobRunId", jobRunId)
+ 
+                 // NOTE: authz is disabled because authz is checked before queueing
+                 Map<String, Object> results = new HashMap<>()

--- a/patches/readme.md
+++ b/patches/readme.md
@@ -118,3 +118,14 @@ Added improvements to prevent scheduled jobs from getting stuck.
 **Job Runner**: Updates job status and locks in a new transaction. This ensures jobs are correctly marked as "Failed" instead of sticking in "Running" when database errors occur.
 
 **Benefit**: Improves stability by ensuring jobs don't get stuck after a crash.
+
+-------------------------------------------------------------------------
+
+### [JobRunId.patch](./JobRunId.patch)
+Added `_jobRunId` to service parameters when a service is called from a job.
+
+When a service job runs, it now puts `_jobRunId` into the service context before calling the actual service. This allows any service running in a job context to access the job run id.
+
+**Use cases:**
+- Services that create records (like `DataManagerLog`) can now read `_jobRunId` from context and save it. This lets you trace exactly which job run created a specific record
+- If something fails inside the service, `_jobRunId` can be included in error messages so you can directly look up the `ServiceJobRun` record for that run.


### PR DESCRIPTION
Close: hotwax/hotwax-maarg-util#36

When a service is called through a service job, the `_jobRunId` is now available in the service context. This allows services to know which job run triggered them and store or use that information as needed.