### PR TITLE
Fix XA connection pool pollution on commit and rollback

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/TransactionFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/TransactionFacadeImpl.groovy
@@ -395,7 +395,6 @@ class TransactionFacadeImpl implements TransactionFacade {
             int status = ut.getStatus()
             // logger.warn("================ commit TX, currentStatus=${status}")
 
-            txStackInfo.closeTxConnections()
             if (status == Status.STATUS_MARKED_ROLLBACK) {
                 if (txStackInfo.rollbackOnlyInfo != null) {
                     logger.warn("Tried to commit transaction but marked rollback only, doing rollback instead; rollback-only was set here:", txStackInfo.rollbackOnlyInfo.rollbackLocation)
@@ -455,8 +454,6 @@ class TransactionFacadeImpl implements TransactionFacade {
         if (ut == null) throw new IllegalStateException("No transaction manager in place")
         TxStackInfo txStackInfo = getTxStackInfo()
         try {
-            txStackInfo.closeTxConnections()
-
             // logger.warn("================ rollback TX, currentStatus=${getStatus()}")
             if (getStatus() == Status.STATUS_NO_TRANSACTION) {
                 logger.warn("Transaction not rolled back, status is STATUS_NO_TRANSACTION")

--- a/patches/XaConnectionPollution.patch
+++ b/patches/XaConnectionPollution.patch
@@ -1,0 +1,21 @@
+diff --git framework/src/main/groovy/org/moqui/impl/context/TransactionFacadeImpl.groovy framework/src/main/groovy/org/moqui/impl/context/TransactionFacadeImpl.groovy
+index 75525163..2a8ed2e9 100644
+--- framework/src/main/groovy/org/moqui/impl/context/TransactionFacadeImpl.groovy
++++ framework/src/main/groovy/org/moqui/impl/context/TransactionFacadeImpl.groovy
+@@ -395,7 +395,6 @@ class TransactionFacadeImpl implements TransactionFacade {
+             int status = ut.getStatus()
+             // logger.warn("================ commit TX, currentStatus=${status}")
+ 
+-            txStackInfo.closeTxConnections()
+             if (status == Status.STATUS_MARKED_ROLLBACK) {
+                 if (txStackInfo.rollbackOnlyInfo != null) {
+                     logger.warn("Tried to commit transaction but marked rollback only, doing rollback instead; rollback-only was set here:", txStackInfo.rollbackOnlyInfo.rollbackLocation)
+@@ -455,8 +454,6 @@ class TransactionFacadeImpl implements TransactionFacade {
+         if (ut == null) throw new IllegalStateException("No transaction manager in place")
+         TxStackInfo txStackInfo = getTxStackInfo()
+         try {
+-            txStackInfo.closeTxConnections()
+-
+             // logger.warn("================ rollback TX, currentStatus=${getStatus()}")
+             if (getStatus() == Status.STATUS_NO_TRANSACTION) {
+                 logger.warn("Transaction not rolled back, status is STATUS_NO_TRANSACTION")

--- a/patches/readme.md
+++ b/patches/readme.md
@@ -129,3 +129,12 @@ When a service job runs, it now puts `_jobRunId` into the service context before
 **Use cases:**
 - Services that create records (like `DataManagerLog`) can now read `_jobRunId` from context and save it. This lets you trace exactly which job run created a specific record
 - If something fails inside the service, `_jobRunId` can be included in error messages so you can directly look up the `ServiceJobRun` record for that run.
+
+-------------------------------------------------------------------------
+
+### [XaConnectionPollution.patch](./XaConnectionPollution.patch)
+Fixed XA connection pool pollution issue caused by closing connections early during commit and rollback.
+
+**Root Cause**: Connections were being closed and returned to the pool before the JTA transaction fully completed, leading to other concurrent threads getting `XAER_RMFAIL` errors when trying to enlist the same connection.
+**Fix**: Removed early `closeTxConnections()` calls inside both the commit and rollback methods. Connections are now safely closed in the `finally` block when the stack clean-up runs, ensuring physical connections are only released back to the pool once their transaction has fully ended.
+


### PR DESCRIPTION
Closes: https://github.com/hotwax/hotwax-maarg-util/issues/163

### Problem
When committing or rolling back, database connections were closed early by calling the connection release method.

In connection pools where connection release deferral is disabled, closing the connection immediately returns the physical database connection to the pool. However, the JTA transaction is still active because the transaction manager has not run the commit/rollback operations yet. 

If another thread borrows this connection from the pool and attempts to enlist it in a new JTA transaction, the transaction manager fails with an XA error (like `XAER_RMFAIL` / "cannot enlist") because the connection is still associated with the active transaction from the previous thread.

### Solution
- Removed the early `closeTxConnections()` calls inside the `commit()` and `rollback()` methods.
- The connections are now safely closed in the `finally` block when `clearCurrent()` is executed. This runs after the JTA transaction has fully committed or rolled back, ensuring the physical connection is only returned to the pool once it is completely free.